### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![deny(clippy::all)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 


### PR DESCRIPTION
This makes this crate show up as clean when it's run through `cargo geiger`.

![image](https://user-images.githubusercontent.com/19805233/236867589-e0340510-a736-43c1-9de3-f379031c1efc.png)
