### PR TITLE
Add additional trait implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.64.0"
 
 [dependencies]
 arbitrary = { version = "1.3.0", default-features = false, features = ["derive"] }
-schemars = { version = "0.8.12", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0.162", default-features = false, features = ["derive"], optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ categories = ["gui"]
 rust-version = "1.64.0"
 
 [dependencies]
+arbitrary = { version = "1.3.0", default-features = false, features = ["derive"] }
+schemars = { version = "0.8.12", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0.162", default-features = false, features = ["derive"], optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["gui"]
 rust-version = "1.64.0"
 
 [dependencies]
-arbitrary = { version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.162", default-features = false, features = ["derive"], optional = true }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,6 @@ extern crate serde;
 #[cfg(feature = "alloc")]
 extern crate alloc as _;
 
-use core::fmt;
-
 /// Describes the appearance of the (usually mouse) cursor icon.
 ///
 /// The names are taken from the CSS W3C specification:
@@ -272,8 +270,8 @@ impl CursorIcon {
     }
 }
 
-impl fmt::Display for CursorIcon {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl core::fmt::Display for CursorIcon {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(self.name())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@ use core::fmt;
 #[non_exhaustive]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CursorIcon {
     /// The platform-dependent default cursor. Often rendered as arrow.
     #[default]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@ use core::fmt;
 #[non_exhaustive]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CursorIcon {
     /// The platform-dependent default cursor. Often rendered as arrow.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,8 @@ extern crate serde;
 #[cfg(feature = "alloc")]
 extern crate alloc as _;
 
+use core::fmt;
+
 /// Describes the appearance of the (usually mouse) cursor icon.
 ///
 /// The names are taken from the CSS W3C specification:
@@ -96,6 +98,8 @@ extern crate alloc as _;
 #[non_exhaustive]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CursorIcon {
     /// The platform-dependent default cursor. Often rendered as arrow.
     #[default]
@@ -267,6 +271,12 @@ impl CursorIcon {
             CursorIcon::ZoomIn => "zoom-in",
             CursorIcon::ZoomOut => "zoom-out",
         }
+    }
+}
+
+impl fmt::Display for CursorIcon {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
     }
 }
 


### PR DESCRIPTION
- Implements `fmt::Display` for easy display capabilities
- ~~Implements `schemars::JsonSchema` so that it can be easily used as a JSON schema~~ Actually, `schemars` is pre-1.0.0, so we can't use it yet
- Implements `arbitrary::Arbitrary` so that it can be used in fuzzing