### PR TITLE
Add documentation and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,4 +45,4 @@ jobs:
         run: cargo test --verbose
 
       - name: Run tests with no default features
-        run: cargo test --verbose --no-default-features
+        run: cargo test --verbose --no-default-features --tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ serde = { version = "1.0.162", default-features = false, features = ["derive"], 
 default = ["std"]
 std = ["alloc"]
 alloc = []
+
+[dev-dependencies]
+wayland-client = "0.30.1"
+wayland-cursor = "0.30.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! The cross platform cursor icon type.
 //!
 //! This type is intended to be used as a standard interopability type between
-//! graphics frameworks in order to convey the cursor icon type.
+//! GUI frameworks in order to convey the cursor icon type.
 //!
 //! # Example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,8 @@ impl core::str::FromStr for CursorIcon {
 /// An error which could be returned when parsing [`CursorIcon`].
 ///
 /// This occurs when the [`FromStr`] implementation of [`CursorIcon`] fails.
+/// 
+/// [`FromStr`]: core::str::FromStr
 #[derive(Debug, PartialEq, Eq)]
 pub struct CursorIconParseError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,23 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! The cross platform cursor icon type.
+//!
+//! This type is intended to be used as a standard interopability type between
+//! graphics frameworks in order to convey the cursor icon type.
+//!
+//! # Example
+//!
+//! ```
+//! use cursor_icon::CursorIcon;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Parse a cursor icon from the string that describes it.
+//! let cursor_name = "pointer";
+//! let cursor_icon: CursorIcon = cursor_name.parse()?;
+//! println!("The cursor icon is {:?}", cursor_icon);
+//! # Ok(())
+//! # }
+//! ```
 
 // This file contains a portion of the CSS Basic User Interface Module Level 3
 // specification. In particular, the names for the cursor from the #cursor
@@ -94,6 +111,15 @@ extern crate alloc as _;
 ///
 /// The names are taken from the CSS W3C specification:
 /// <https://www.w3.org/TR/css-ui-3/#cursor>
+///
+/// # Examples
+///
+/// ```
+/// use cursor_icon::CursorIcon;
+///
+/// // Get the cursor icon for the default cursor.
+/// let cursor_icon = CursorIcon::Default;
+/// ```
 #[non_exhaustive]
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -231,6 +257,30 @@ impl CursorIcon {
     ///
     /// This name most of the time could be passed as is to cursor loading
     /// libraries on X11/Wayland and could be used as-is on web.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use cursor_icon::CursorIcon;
+    /// use wayland_cursor::CursorTheme;
+    ///
+    /// # use wayland_client::Connection;
+    /// # use wayland_client::protocol::wl_shm::WlShm;
+    /// # fn test(conn: &Connection, shm: WlShm) -> Result<(), Box<dyn std::error::Error>> {
+    /// // Choose a cursor to load.
+    /// let cursor = CursorIcon::Help;
+    ///
+    /// // Load the Wayland cursor theme.
+    /// let mut cursor_theme = CursorTheme::load(conn, shm, 32)?;
+    ///
+    /// // Load the cursor.
+    /// let cursor = cursor_theme.get_cursor(cursor.name());
+    /// if let Some(cursor) = cursor {
+    ///     println!("Total number of images: {}", cursor.image_count());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn name(&self) -> &'static str {
         match self {
             CursorIcon::Default => "default",
@@ -316,6 +366,8 @@ impl core::str::FromStr for CursorIcon {
 }
 
 /// An error which could be returned when parsing [`CursorIcon`].
+///
+/// This occurs when the [`FromStr`] implementation of [`CursorIcon`] fails.
 #[derive(Debug, PartialEq, Eq)]
 pub struct CursorIconParseError;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,7 +368,7 @@ impl core::str::FromStr for CursorIcon {
 /// An error which could be returned when parsing [`CursorIcon`].
 ///
 /// This occurs when the [`FromStr`] implementation of [`CursorIcon`] fails.
-/// 
+///
 /// [`FromStr`]: core::str::FromStr
 #[derive(Debug, PartialEq, Eq)]
 pub struct CursorIconParseError;


### PR DESCRIPTION
Makes sure this crate fulfills the [`C-EXAMPLE`](https://rust-lang.github.io/api-guidelines/documentation.html#c-example) requirement, for the most part.