### PR TITLE
Rename `CursorIconParseError` to just `ParseError`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ impl CursorIcon {
 }
 
 impl core::str::FromStr for CursorIcon {
-    type Err = CursorIconParseError;
+    type Err = ParseError;
 
     fn from_str(name: &str) -> Result<Self, Self::Err> {
         match name {
@@ -310,22 +310,22 @@ impl core::str::FromStr for CursorIcon {
             "all-scroll" => Ok(CursorIcon::AllScroll),
             "zoom-in" => Ok(CursorIcon::ZoomIn),
             "zoom-out" => Ok(CursorIcon::ZoomOut),
-            _ => Err(CursorIconParseError { _private: () }),
+            _ => Err(ParseError { _private: () }),
         }
     }
 }
 
 /// An error which could be returned when parsing [`CursorIcon`].
 #[derive(Debug, PartialEq, Eq)]
-pub struct CursorIconParseError {
+pub struct ParseError {
     _private: (),
 }
 
-impl core::fmt::Display for CursorIconParseError {
+impl core::fmt::Display for ParseError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str("failed to parse cursor icon")
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for CursorIconParseError {}
+impl std::error::Error for ParseError {}


### PR DESCRIPTION
The latter is precise enough given the name of the crate.