### PR TITLE
Implement `Hash` for `ParseError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Implement `Hash` for `ParseError`.
+
 ## 1.1.0
 
 - Bump MSRV from `1.64` to `1.65`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,7 +427,7 @@ impl core::str::FromStr for CursorIcon {
 /// This occurs when the [`FromStr`] implementation of [`CursorIcon`] fails.
 ///
 /// [`FromStr`]: core::str::FromStr
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct ParseError {
     _private: (),
 }


### PR DESCRIPTION
This implements `Hash` for `ParseError`.
I assume that `Clone` and `Copy` wasn't added because potentially in the future some data might be added to `ParseError`?

~~I also replaced `ParseError::_private` with `#[non_exhaustive]`, kinda the new Rusty way to do this. Let me know if you want me to split this into a separate PR.~~