### PR TITLE
chore: remove deprecated feature cargo-clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
-#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
+#![cfg_attr(clippy, deny(warnings))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! The cross platform cursor icon type.


### PR DESCRIPTION
--

@daxpedda we have the exact same one in winit if it matters. It's just to automatically throw errors when running clippy, so they are more likely to get fixed.