### PR TITLE
add new wayland cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Implement `Hash` for `ParseError`.
+- Add `CursorIcon::DndAsk` and `CursorIcon::AllResize` from the wayland-protocols version 1.42 
 
 ## 1.1.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,14 +254,22 @@ pub enum CursorIcon {
     ZoomOut,
 
     /// Indicates that the user will select the action that will be carried out.
+    ///
+    /// This is a non-standard extension of the w3c standard used in freedesktop
+    /// cursor icon themes.
     DndAsk,
 
     /// Indicates that something can be moved or resized in any direction.
+    ///
+    /// This is a non-standard extension of the w3c standard used in freedesktop
+    /// cursor icon themes.
     AllResize,
 }
 
 impl CursorIcon {
-    /// The name of the cursor icon as defined in w3c standard.
+    /// The name of the cursor icon as defined in the w3c standard.
+    /// Non-standard cursors such as "DndAsk" and "AllResize" are translated as
+    /// "dnd-ask" and "all-resize" respectively.
     ///
     /// This name most of the time could be passed as is to cursor loading
     /// libraries on X11/Wayland and could be used as-is on web.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,12 @@ pub enum CursorIcon {
     /// Indicates that something can be zoomed in. Often rendered as a
     /// magnifying glass with a "-" in the center of the glass.
     ZoomOut,
+
+    /// Indicates that the user will select the action that will be carried out.
+    DndAsk,
+
+    /// Indicates that something can be moved or resized in any direction.
+    AllResize,
 }
 
 impl CursorIcon {
@@ -319,6 +325,8 @@ impl CursorIcon {
             CursorIcon::AllScroll => "all-scroll",
             CursorIcon::ZoomIn => "zoom-in",
             CursorIcon::ZoomOut => "zoom-out",
+            CursorIcon::DndAsk => "dnd-ask",
+            CursorIcon::AllResize => "all-resize",
         }
     }
 
@@ -363,6 +371,8 @@ impl CursorIcon {
             CursorIcon::AllScroll => &["size_all"],
             CursorIcon::ZoomIn => &[],
             CursorIcon::ZoomOut => &[],
+            CursorIcon::DndAsk => &["copy"],
+            CursorIcon::AllResize => &["move"],
         }
     }
 }


### PR DESCRIPTION
added the new `dnd-ask` and `all-resize` as specified in [wayland/wayland-protocols!294](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/294). one concern is, that the names might not be final (especially for `dnd-ask`), and changing them later would be a breaking change. i think that could potentially be mitigated by adding a new enum variant and deprecating the current, but i also think that it will probably take some time (if it will even happen) for wayland to change the naming, so it should probably be fine for a while.

[mutter falls back to `dnd-copy` and `dnd-move`](https://gitlab.gnome.org/GNOME/mutter/-/blob/ef21f2307e3ecb64e98c55cb6141a862999f0f06/src/backends/meta-cursor-sprite-xcursor.c#L208-211) while [kwin falls back to `copy` and `move`](https://invent.kde.org/plasma/kwin/-/merge_requests/7253). since this repo consistently uses the `dnd`-less versions, i decided to fall back to `copy` and `move` respectively.

i don't know what description to add to those: breeze doesn't have them and the only ones i could find for the new dnd-ask icon were in the [adwaita docs](https://gitlab.gnome.org/GNOME/gtk/-/blob/739467d16fc465089dcfc4defd5a80dbf1b9d044/docs/reference/gdk/images/dnd_ask_cursor.png) and from [bibata](https://github.com/ful1e5/Bibata_Cursor/blob/35ccfe209a808e40d6c2ca60a46cbe4faf68b690/svg/groups/hand/dnd-ask.svg) who are drawing them very differently. (though bibata does some other strange decisions like having a different cursor for [`dnd-copy`](https://github.com/ful1e5/Bibata_Cursor/blob/35ccfe209a808e40d6c2ca60a46cbe4faf68b690/svg/groups/hand/dnd-copy.svg) and [`copy`](https://github.com/ful1e5/Bibata_Cursor/blob/35ccfe209a808e40d6c2ca60a46cbe4faf68b690/svg/groups/modern/copy.svg)). if you want me to i could add a description like `/// Often drawn as an arrow with either a small question mark or three dots next to it`, but i just left it for now.